### PR TITLE
Functional chat, fixed reconnect issues

### DIFF
--- a/Bartleby/Bartleby/AppDelegate.m
+++ b/Bartleby/Bartleby/AppDelegate.m
@@ -31,7 +31,8 @@
 
 - (void)applicationDidEnterBackground:(UIApplication *)application {
     // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
-    // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+
+    [[DataSource sharedInstance] saveConversationsToDisk];
 }
 
 - (void)applicationWillEnterForeground:(UIApplication *)application {
@@ -44,6 +45,9 @@
 
 - (void)applicationWillTerminate:(UIApplication *)application {
     // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+    
+    [[DataSource sharedInstance] saveConversationsToDisk];
+
 }
 
 @end

--- a/Bartleby/Bartleby/ConversationViewController.m
+++ b/Bartleby/Bartleby/ConversationViewController.m
@@ -79,6 +79,7 @@
     if (editingStyle == UITableViewCellEditingStyleDelete) {
          // Delete the row from the data source
          [[DataSource sharedInstance].activeConversations removeObjectAtIndex:indexPath.row];
+          
          [tableView deleteRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationFade];
          
          [self checkEmptyTableView]; 

--- a/Bartleby/Bartleby/DataSource.h
+++ b/Bartleby/Bartleby/DataSource.h
@@ -25,9 +25,8 @@
 @property (nonatomic, strong) NSString *serviceType;
 @property (retain, nonatomic) MCNearbyServiceAdvertiser *advertiser;
 
-
+//Used
 @property (nonatomic, strong) NSMutableArray *availablePeers;
-@property (nonatomic, strong) NSMutableArray *connectedPeers;
 
 @property (nonatomic, strong) NSMutableArray *activeConversations;
 
@@ -41,6 +40,9 @@
 + (instancetype) sharedInstance;
 
 - (SessionContainer *) createNewSessionWithPeerID:(MCPeerID *)peerID;
+
+//Save active conversations property to disk. Use whenever activeConversations is updated. 
+- (void) saveConversationsToDisk;
 
 //KVO methods - made public since changes are made to Active Conversations by SessionContainer during connections
 - (NSUInteger) countOfActiveConversations;

--- a/Bartleby/Bartleby/DataSource.m
+++ b/Bartleby/Bartleby/DataSource.m
@@ -41,17 +41,32 @@ NSString *const kDSServiceType = @"bartleby-chat";
         self.serviceType = kDSServiceType;
         self.userID = [[MCPeerID alloc] initWithDisplayName:[[UIDevice currentDevice] name]];
         
+        self.availablePeers = [NSMutableArray new];
+
         //start advertiser on app start.
         self.advertiser = [[MCNearbyServiceAdvertiser alloc] initWithPeer:self.userID discoveryInfo:nil serviceType:self.serviceType];
         self.advertiser.delegate = self;
         [self.advertiser startAdvertisingPeer];
         
-        //initialize arrays
-        self.activeConversations = [NSMutableArray new];
-        self.availablePeers = [NSMutableArray new];
-        self.connectedPeers = [NSMutableArray new];
-        
-        //Used by ConversationViewController to tell ChatViewController when user is creating a new conversation. 
+        //read active conversation data, and if there is none, initialize array.
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+            NSString *fullPath = [self pathForFilename:NSStringFromSelector(@selector(activeConversations))];
+            NSArray *storedActiveConversations = [NSKeyedUnarchiver unarchiveObjectWithFile:fullPath];
+            
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if (storedActiveConversations.count > 0) {
+                    NSMutableArray *mutableActiveConversations = [storedActiveConversations mutableCopy];
+                    
+                    [self willChangeValueForKey:@"activeConversations"];
+                    self.activeConversations = mutableActiveConversations;
+                    [self didChangeValueForKey:@"activeConversations"];
+                } else {
+                    self.activeConversations = [NSMutableArray new];
+                }
+            });
+        });
+
+        //Used by ConversationViewController to tell ChatViewController when user is creating a new conversation.
         self.isNewConversation = NO;
         
     }
@@ -91,14 +106,30 @@ NSString *const kDSServiceType = @"bartleby-chat";
 
 - (void)alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex {
     
+    BOOL noPreviousConversation = YES;
+    
     BOOL accept = (buttonIndex != alertView.cancelButtonIndex) ? YES : NO;
-    
-    SessionContainer *newSession = [[DataSource sharedInstance] createNewSessionWithPeerID:self.invitationPeer];
-    self.ConvWithInitialConnectionInProgress = newSession;
     void (^invitationHandler)(BOOL, MCSession *) = [self.invitationHandler objectAtIndex:0];
+
+    for (SessionContainer *activeConversation in self.activeConversations) {
+        if ([activeConversation.displayName isEqualToString:self.invitationPeer.displayName]) {
+            
+            invitationHandler(accept, activeConversation.session);
+            
+            noPreviousConversation = NO;
+        }
+    }
+    //ASK STEVE ABOUT POINTERS.
+    if (noPreviousConversation) {
+        
+        SessionContainer *newSession = [[DataSource sharedInstance] createNewSessionWithPeerID:self.invitationPeer];
+        self.ConvWithInitialConnectionInProgress = newSession;
+        invitationHandler(accept, newSession.session);
+        
+    }
     
-    invitationHandler(accept, newSession.session);
-    
+    //check new session against existing sessions. If one already exists, replace it. If not, create new session.
+
 }
 
 
@@ -122,24 +153,56 @@ NSString *const kDSServiceType = @"bartleby-chat";
 
 - (void) insertObject:(SessionContainer *)object inActiveConversationsAtIndex:(NSUInteger)index {
     [_activeConversations insertObject:object atIndex:index];
+    [self saveConversationsToDisk];
 }
 
 - (void) removeObjectFromActiveConversationsAtIndex:(NSUInteger)index {
     [_activeConversations removeObjectAtIndex:index];
+    [self saveConversationsToDisk];
 }
 
 - (void) replaceObjectInActiveConversationsAtIndex:(NSUInteger)index withObject:(id)object {
     [_activeConversations replaceObjectAtIndex:index withObject:object];
+    [self saveConversationsToDisk];
 }
 
 -(void) deleteActiveConversation:(SessionContainer *)activeConversation {
     NSMutableArray *mutableArrayWithKVO = [self mutableArrayValueForKey:@"activeConversations"];
     [mutableArrayWithKVO removeObject:activeConversation];
+    [self saveConversationsToDisk];
 }
 
 - (void) addActiveConversationsObject:(SessionContainer *)activeConversation {
     NSMutableArray *mutableArrayWithKVO = [self mutableArrayValueForKey:@"activeConversations"];
     [mutableArrayWithKVO addObject:activeConversation];
+    [self saveConversationsToDisk];
+}
+
+#pragma mark - Keyed Archiver
+
+- (NSString *) pathForFilename:(NSString *) filename {
+    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
+    NSString *documentsDirectory = [paths firstObject];
+    NSString *dataPath = [documentsDirectory stringByAppendingPathComponent:filename];
+    return dataPath;
+}
+
+- (void) saveConversationsToDisk {
+    // Write active conversations to disk.
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        NSUInteger numberOfItemsToSave = MIN(self.activeConversations.count, 50);
+        NSArray *activeConversationsToSave = [self.activeConversations subarrayWithRange:NSMakeRange(0, numberOfItemsToSave)];
+        
+        NSString *fullPath = [self pathForFilename:NSStringFromSelector(@selector(activeConversations))];
+        NSData *mediaItemData = [NSKeyedArchiver archivedDataWithRootObject:activeConversationsToSave];
+        
+        NSError *dataError;
+        BOOL wroteSuccessfully = [mediaItemData writeToFile:fullPath options:NSDataWritingAtomic | NSDataWritingFileProtectionCompleteUnlessOpen error:&dataError];
+        
+        if (!wroteSuccessfully) {
+            NSLog(@"Couldn't write file: %@", dataError);
+        }
+    });
 }
 
 @end

--- a/Bartleby/Bartleby/MainStoryboard_iPhone.storyboard
+++ b/Bartleby/Bartleby/MainStoryboard_iPhone.storyboard
@@ -71,7 +71,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="coN-sD-VBL" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="401" y="32"/>
+            <point key="canvasLocation" x="413" y="32"/>
         </scene>
         <!--Peer Browser Table View Controller-->
         <scene sceneID="AFc-SL-njv">

--- a/Bartleby/Bartleby/PeerBrowserTableViewController.m
+++ b/Bartleby/Bartleby/PeerBrowserTableViewController.m
@@ -173,9 +173,7 @@
     [self.browser invitePeer:peerToConnect toSession:[DataSource sharedInstance].currentConversation.session
                  withContext:nil
                      timeout:30];
-    
-    [[DataSource sharedInstance].connectedPeers addObject:peerToConnect];
-    
+        
     [self.tableView deselectRowAtIndexPath:indexPath animated:YES];
     [self dismissViewControllerAnimated:YES completion:nil]; 
     

--- a/Bartleby/Bartleby/SessionContainer.h
+++ b/Bartleby/Bartleby/SessionContainer.h
@@ -15,14 +15,13 @@
 @protocol SessionContainerDelegate;
 
 // Container utility class for managing MCSession state, API calls, and it's delegate callbacks
-@interface SessionContainer : NSObject <MCSessionDelegate>
+@interface SessionContainer : NSObject <NSCoding, MCSessionDelegate>
+
+@property (nonatomic, assign) id <SessionContainerDelegate> delegate;
 
 @property (nonatomic, readonly) MCSession *session;
-@property (nonatomic, assign) id<SessionContainerDelegate> delegate;
 @property (nonatomic, strong) NSMutableArray *sessionTranscripts;
-
-@property (nonatomic, strong) NSString *displayName; 
-
+@property (nonatomic, strong) NSString *displayName;
 //Used to track any peers that have ever been connected to the session.
 @property (nonatomic, strong) NSMutableArray *peersConnectedToSession;
 

--- a/Bartleby/Bartleby/Transcript.h
+++ b/Bartleby/Bartleby/Transcript.h
@@ -17,7 +17,7 @@ typedef enum {
     TRANSCRIPT_DIRECTION_LOCAL // for admin messages. i.e. "<name> connected"
 } TranscriptDirection;
 
-@interface Transcript : NSObject
+@interface Transcript : NSObject <NSCoding>
 
 // Direction of the transcript
 @property (readonly, nonatomic) TranscriptDirection direction;

--- a/Bartleby/Bartleby/Transcript.m
+++ b/Bartleby/Bartleby/Transcript.m
@@ -43,4 +43,33 @@
     return [self initWithPeerID:peerID message:nil imageName:imageName imageUrl:nil progress:progress direction:direction];
 }
 
+#pragma mark - NSCoding
+
+- (instancetype) initWithCoder:(NSCoder *)aDecoder {
+    self = [super init];
+    
+    if (self) {
+        _peerID = [aDecoder decodeObjectForKey:NSStringFromSelector(@selector(peerID))];
+        _direction = [aDecoder decodeIntForKey:NSStringFromSelector(@selector(direction))];
+        _message = [aDecoder decodeObjectForKey:NSStringFromSelector(@selector(message))];
+        _imageName = [aDecoder decodeObjectForKey:NSStringFromSelector(@selector(imageName))];
+        _imageUrl = [aDecoder decodeObjectForKey:NSStringFromSelector(@selector(imageName))];
+        
+    }
+    
+    return self;
+}
+
+- (void) encodeWithCoder:(NSCoder *)aCoder {
+    
+    //session not saved. Reinitialize when initializing from coder.
+    [aCoder encodeInt:self.direction forKey:NSStringFromSelector(@selector(direction))];
+    [aCoder encodeObject:self.peerID forKey:NSStringFromSelector(@selector(peerID))];
+    [aCoder encodeObject:self.message forKey:NSStringFromSelector(@selector(message))];
+    [aCoder encodeObject:self.imageName forKey:NSStringFromSelector(@selector(imageName))];
+    [aCoder encodeObject:self.imageUrl forKey:NSStringFromSelector(@selector(imageUrl))];
+    
+}
+
+
 @end


### PR DESCRIPTION
Tightened up the data models and fixed chat bugs: 
1. Fixed bug causing app to crash when messages were sent to user when they were not in chat view. 
2. Conversations now persist through app closing/launch. 
3. App checks if peers are still connected when re-entering chat. If not, displays new message to the user to reconnect. 
4. When reconnecting, fixed bug that created multiple instances of chat with same peer. 

General UI in chat view still has some bugs (photo messages in particular.) Will be cleaned up in subsequent builds.
